### PR TITLE
[Experiment] Header breadcrumb  

### DIFF
--- a/src/app/components/shared/SecondaryHeader.tsx
+++ b/src/app/components/shared/SecondaryHeader.tsx
@@ -9,7 +9,6 @@ import { PencilIcon, SidebarExpandIcon } from "@primer/octicons-react";
 import { SpaceSelector } from "./SpaceSelector";
 import { type Space } from "../../data/spaces";
 import { useRouter, usePathname } from "next/navigation";
-import ReusableBreadcrumb from "./header/ReusableBreadcrumb";
 
 interface SecondaryHeaderProps {
   showModelSelector?: boolean;
@@ -42,13 +41,20 @@ export const SecondaryHeader: FC<SecondaryHeaderProps> = ({
 }) => {
   const [selectedModel] = useState("GPT-4o");
   const router = useRouter();
+  const currentPathname = pathname || usePathname();
+
+  // Extract conversation title path section if it exists
+  const pathParts = currentPathname.split("/");
+  const isConversationPath =
+    currentPathname.startsWith("/conversations/") ||
+    (currentPathname.startsWith("/spaces/") && pathParts.length > 3);
 
   return (
     <div className="h-[49px] flex items-center px-4 dark:border-gray-800 sticky top-0 bg-white dark:bg-gray-900 z-2">
-      {/* Left section */}
+      {/* Left section - Sidebar buttons */}
       <div className="flex items-center gap-3 relative z-10">
         {sidebarCollapsed && (
-          <>
+          <div className="flex items-center gap-2 flex-shrink-0">
             <Button
               variant="outline"
               className="w-8 h-8"
@@ -65,27 +71,25 @@ export const SecondaryHeader: FC<SecondaryHeaderProps> = ({
             >
               <PencilIcon size={16} />
             </Button>
-          </>
+          </div>
         )}
       </div>
 
-      {/* Center section - Breadcrumb or Space Selector with optional Model selector */}
+      {/* Center section - Conversation Title or Space Selector with optional Model selector */}
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-4">
         {showSpaceSelector && onSelectSpace ? (
-          // Case 1: Empty conversation - show current selector
+          // Case 1: Empty conversation - show space selector
           <SpaceSelector
             selectedSpace={selectedSpace}
             onSelectSpace={onSelectSpace}
           />
         ) : (
-          // Cases 2-5: Show appropriate breadcrumb based on path
-          <ReusableBreadcrumb
-            title={title}
-            spaceIcon={spaceIcon}
-            spaceColor={spaceColor}
-            showCopilot={false}
-            pathname={pathname}
-          />
+          // Show conversation title for all contexts
+          <div className="flex items-center">
+            <h1 className="text-sm font-medium text-gray-800 truncate max-w-[240px]">
+              {title || ""}
+            </h1>
+          </div>
         )}
 
         {showModelSelector && (

--- a/src/app/components/shared/header/LeftSection.tsx
+++ b/src/app/components/shared/header/LeftSection.tsx
@@ -7,16 +7,15 @@ import { Button } from "@/components/ui/button";
 
 export const LeftSection: FC = () => {
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-center gap-3 flex-shrink-0">
       <Button variant="outline" className="w-8 h-8">
         <ThreeBarsIcon size={16} />
       </Button>
 
-      <Link href="/" className="text-fg-default">
-        <MarkGithubIcon size={32} />
+      <Link href="/" className="text-fg-default flex items-center gap-2">
+        <MarkGithubIcon size={24} />
+        <span className="text-sm font-medium">Copilot</span>
       </Link>
-
-      <span className="text-sm font-medium">Copilot</span>
     </div>
   );
 };

--- a/src/app/components/shared/header/ReusableBreadcrumb.tsx
+++ b/src/app/components/shared/header/ReusableBreadcrumb.tsx
@@ -38,6 +38,7 @@ export interface ReusableBreadcrumbProps {
   displayMode?: "full" | "responsive" | "last-only";
   copilotName?: string;
   showCopilot?: boolean;
+  excludeConversationTitle?: boolean;
 }
 
 interface BreadcrumbItemComponentProps {
@@ -111,10 +112,10 @@ const BreadcrumbItemComponent: FC<BreadcrumbItemComponentProps> = ({
       )}
       <span
         className={cn(
-          "text-sm font-medium text-gray-700 truncate",
+          "text-sm font-medium truncate",
           // If it's a conversation title and not part of a space (no icon), give it more width
           item.icon ? "max-w-[160px]" : "max-w-[240px]",
-          isLast && "text-gray-800"
+          isLast ? "text-gray-800" : "text-gray-600 hover:text-gray-800"
         )}
       >
         {item.text}
@@ -140,7 +141,11 @@ const BreadcrumbItemComponent: FC<BreadcrumbItemComponentProps> = ({
   return (
     <>
       {item.href ? (
-        <Link href={item.href} onClick={handleClick}>
+        <Link
+          href={item.href}
+          onClick={handleClick}
+          className="hover:no-underline"
+        >
           {content}
         </Link>
       ) : (
@@ -159,6 +164,7 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
   displayMode = "responsive",
   copilotName = "Copilot",
   showCopilot = true,
+  excludeConversationTitle = false,
 }) => {
   const pathname = propPathname || usePathname();
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -190,10 +196,8 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
   // Define breadcrumb items based on the current path
   const items: BreadcrumbItem[] = [];
 
-  // Only add Copilot as the first item if showCopilot is true
-  if (showCopilot) {
-    items.push({ text: copilotName, href: "/" });
-  }
+  // Always add Copilot as the first item regardless of showCopilot prop
+  items.push({ text: copilotName, href: "/" });
 
   // Empty conversation state
   if (pathname === "/") {
@@ -220,13 +224,8 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
       });
     }
 
-    // If there's a conversation (deeper path)
-    if (pathname.split("/").length > 3) {
-      const conversationTitle = title || "Conversation";
-      items.push({
-        text: conversationTitle,
-      });
-    }
+    // We're excluding conversation titles (handled in SecondaryHeader)
+    // So we don't add the conversation title here anymore
   }
   // Non-space conversation state
   else if (pathname.startsWith("/conversations/")) {
@@ -265,20 +264,28 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
         });
       }
 
-      items.push({
-        text: foundConversation.title || title || "Conversation",
-      });
-    } else {
-      // If conversation doesn't belong to a space or wasn't found
+      // We're excluding conversation titles (handled in SecondaryHeader)
+      // So we don't add the conversation title here anymore
+    } else if (!excludeConversationTitle) {
+      // Only if we're not in a space AND we're not excluding conversation titles
+      // (This is likely not needed given our current setup)
       items.push({ text: title || "Conversation" });
     }
   } else if (pathname === "/pipes") {
     items.push({ text: "Pipes", href: "/pipes" });
   }
 
-  // If no items (besides possibly Copilot), return null
-  if (items.length === (showCopilot ? 1 : 0)) {
-    return null;
+  // If there are no items besides Copilot, show at least Copilot
+  if (items.length === 1) {
+    return (
+      <div className="flex items-center">
+        <BreadcrumbItemComponent
+          item={items[0]}
+          isLast={true}
+          onNavigate={() => setIsOpen(false)}
+        />
+      </div>
+    );
   }
 
   // For last-only display mode or collapsed responsive mode
@@ -290,22 +297,6 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
     let iconToShow = lastItem.icon;
     let iconColorToShow = lastItem.iconColor;
 
-    // If this is a conversation in a space and the last item doesn't have an icon
-    // (i.e., it's the conversation title), look for the space icon from previous items
-    if (
-      pathname.startsWith("/conversations/") ||
-      (pathname.startsWith("/spaces/") && pathname.split("/").length > 3)
-    ) {
-      if (!lastItem.icon) {
-        // Find the space item (should be the item before the last if this is a space conversation)
-        const spaceItem = items.find((item) => item.spaceId && item.icon);
-        if (spaceItem) {
-          iconToShow = spaceItem.icon;
-          iconColorToShow = spaceItem.iconColor;
-        }
-      }
-    }
-
     const IconComponent = iconToShow ? getIconComponent(iconToShow) : null;
 
     return (
@@ -313,7 +304,7 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
         <PopoverTrigger asChild>
           <Button
             variant="ghost"
-            className="p-1 flex items-center gap-2 h-auto hover:bg-gray-100"
+            className="p-1 -ml-3 flex items-center gap-2 h-auto hover:bg-gray-100"
           >
             {IconComponent && (
               <div
@@ -325,7 +316,7 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
                 </div>
               </div>
             )}
-            <span className="text-sm font-medium text-gray-800">
+            <span className="text-sm font-medium text-gray-800 truncate max-w-[120px]">
               {lastItem.text}
             </span>
             <ChevronDownIcon size={16} className="text-gray-500" />
@@ -334,23 +325,10 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
         <PopoverContent className="w-56 p-2" align="start" sideOffset={8}>
           <div className="flex flex-col">
             <div className="text-xs text-gray-500 px-2 py-1">Navigate to</div>
-            <Button
-              variant="ghost"
-              className="justify-start px-2 py-2 h-auto text-left"
-              onClick={() => {
-                router.push("/");
-                setIsOpen(false);
-              }}
-            >
-              <div className="flex items-center gap-2">
-                <HomeIcon size={14} className="text-gray-500 mx-0.5" />
-                <span className="text-sm">Dashboard</span>
-              </div>
-            </Button>
             {items
               .filter((item) => item.href)
               .map((item, index) => {
-                // Use the space icon if it exists, otherwise check if it's a Spaces link
+                // Same as before
                 const isSpacesLink =
                   item.text === "Spaces" && item.href === "/spaces";
                 const ItemIconComponent = item.icon
@@ -381,7 +359,9 @@ export const ReusableBreadcrumb: FC<ReusableBreadcrumbProps> = ({
                         </div>
                       ) : isSpacesLink ? (
                         <StarIcon size={16} className="text-gray-500 mx-0.5" />
-                      ) : null}
+                      ) : (
+                        <HomeIcon size={16} className="text-gray-500 mx-0.5" />
+                      )}
                       <span className="text-sm">{item.text}</span>
                     </div>
                   </Button>

--- a/src/app/components/shared/header/RightSection.tsx
+++ b/src/app/components/shared/header/RightSection.tsx
@@ -1,29 +1,89 @@
-import { FC } from "react";
+import { FC, useState, useRef, useEffect } from "react";
 import {
   SearchIcon,
   PlusIcon,
   InboxIcon,
   IssueOpenedIcon,
   GitPullRequestIcon,
+  XIcon,
 } from "@primer/octicons-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import Image from "next/image";
+import { useMediaQuery } from "@/app/hooks/useMediaQuery";
 
 export const RightSection: FC = () => {
+  const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const isMobile = useMediaQuery("(max-width: 768px)");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const toggleSearch = () => {
+    setIsSearchExpanded(!isSearchExpanded);
+  };
+
+  // Handle clicks outside of the search input to collapse it on mobile
+  useEffect(() => {
+    if (!isSearchExpanded) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node) &&
+        isMobile
+      ) {
+        setIsSearchExpanded(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isSearchExpanded, isMobile]);
+
+  // Focus the input when expanded
+  useEffect(() => {
+    if (isSearchExpanded && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isSearchExpanded]);
+
   return (
     <div className="flex items-center gap-2">
-      <div className="relative">
-        <Input
-          type="text"
-          placeholder="Search or jump to..."
-          className="pl-8"
-        />
-        <SearchIcon
-          size={16}
-          className="absolute left-2 top-2.5 text-gray-500"
-        />
-      </div>
+      {/* Desktop search input or mobile expanded search */}
+      {!isMobile || isSearchExpanded ? (
+        <div className="relative transition-all duration-200 ease-in-out">
+          <Input
+            ref={inputRef}
+            type="text"
+            placeholder="Search or jump to..."
+            className="pl-8 transition-all duration-200 ease-in-out"
+          />
+          <SearchIcon
+            size={16}
+            className="absolute left-2 top-2.5 text-gray-500"
+          />
+          {isSearchExpanded && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 top-1.5 h-6 w-6"
+              onClick={toggleSearch}
+            >
+              <XIcon size={12} />
+            </Button>
+          )}
+        </div>
+      ) : (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="w-8 h-8 transition-all duration-200 ease-in-out"
+          onClick={toggleSearch}
+        >
+          <SearchIcon size={16} />
+        </Button>
+      )}
 
       <Button variant="outline" className="hidden md:flex w-8 h-8">
         <PlusIcon size={16} />

--- a/src/app/components/shared/header/index.tsx
+++ b/src/app/components/shared/header/index.tsx
@@ -1,13 +1,31 @@
 "use client";
 
 import { FC } from "react";
-import { LeftSection } from "./LeftSection";
 import { RightSection } from "./RightSection";
+import ReusableBreadcrumb from "./ReusableBreadcrumb";
+import { Button } from "@/components/ui/button";
+import { ThreeBarsIcon, MarkGithubIcon } from "@primer/octicons-react";
+import Link from "next/link";
 
 export const Header: FC = () => {
   return (
     <header className="flex items-center justify-between px-4 bg-gray-50 py-3 text-gray-700 border-b border-gray-200">
-      <LeftSection />
+      <div className="flex items-center overflow-hidden">
+        <div className="flex items-center gap-3 flex-shrink-0 mr-4">
+          <Button variant="outline" className="w-8 h-8">
+            <ThreeBarsIcon size={16} />
+          </Button>
+          <Link href="/" className="text-fg-default">
+            <MarkGithubIcon size={24} />
+          </Link>
+        </div>
+        <div className="overflow-hidden">
+          <ReusableBreadcrumb
+            displayMode="responsive"
+            excludeConversationTitle={true}
+          />
+        </div>
+      </div>
       <RightSection />
     </header>
   );

--- a/src/app/hooks/useMediaQuery.ts
+++ b/src/app/hooks/useMediaQuery.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * Custom hook to detect if a media query matches
+ * @param query The media query to check
+ * @returns Boolean indicating if the media query matches
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    // Check if we're in a browser environment
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(query);
+
+    // Set initial value
+    setMatches(mediaQuery.matches);
+
+    // Define callback function to handle changes
+    const handler = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    // Add event listener
+    mediaQuery.addEventListener("change", handler);
+
+    // Clean up
+    return () => {
+      mediaQuery.removeEventListener("change", handler);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -19,7 +19,7 @@ export default function SpacesPage() {
   }, []);
 
   return (
-    <div className="max-w-[880px] mx-auto px-8">
+    <div className="max-w-[880px] mx-auto px-8 pt-8">
       <PageTitle
         icon="star"
         title="Spaces"


### PR DESCRIPTION
Breadcrumb experiment. 

![CleanShot 2025-05-19 at 10 22 54@2x](https://github.com/user-attachments/assets/e20b9958-4a49-4d9f-95bc-0d2f6e421a38)


### Header Component Enhancements:

* [`src/app/components/shared/SecondaryHeader.tsx`](diffhunk://#diff-f4fd2deb40868f06d9360621d77268434be6bd496fe6366180bc5d48241eb3cfR44-R57): Updated to include logic for extracting conversation titles from the path and displaying them in the header. Removed the `ReusableBreadcrumb` component and replaced it with a simpler title display. [[1]](diffhunk://#diff-f4fd2deb40868f06d9360621d77268434be6bd496fe6366180bc5d48241eb3cfR44-R57) [[2]](diffhunk://#diff-f4fd2deb40868f06d9360621d77268434be6bd496fe6366180bc5d48241eb3cfL68-R92)

* [`src/app/components/shared/header/ReusableBreadcrumb.tsx`](diffhunk://#diff-dc128c288f3789ea5ef42fa29e3683cdae7d8d8eeeaafda16e45c356caac90eaR41): Added a new prop `excludeConversationTitle` to control whether conversation titles should be included in the breadcrumb. Adjusted the logic to exclude conversation titles when necessary and improved the behavior of the space preview popover. [[1]](diffhunk://#diff-dc128c288f3789ea5ef42fa29e3683cdae7d8d8eeeaafda16e45c356caac90eaR41) [[2]](diffhunk://#diff-dc128c288f3789ea5ef42fa29e3683cdae7d8d8eeeaafda16e45c356caac90eaR59) [[3]](diffhunk://#diff-dc128c288f3789ea5ef42fa29e3683cdae7d8d8eeeaafda16e45c356caac90eaR69-R123) [[4]](diffhunk://#diff-dc128c288f3789ea5ef42fa29e3683cdae7d8d8eeeaafda16e45c356caac90eaL114-R168)

* [`src/app/components/shared/header/RightSection.tsx`](diffhunk://#diff-19f28dbdedb18aa4fcc09ff8fd303eb52d23f0d3be92c753f64c92515191fe0bL1-R86): Enhanced to include an expandable search input for mobile devices, with logic to handle clicks outside the input to collapse it and focus on expansion.

### Custom Hook:

* [`src/app/hooks/useMediaQuery.ts`](diffhunk://#diff-f080c441f37a852e0db35cdd4243ad3f502cf2a7dbe90cec81c16ccd28511687R1-R39): Introduced a new custom hook `useMediaQuery` to detect if a media query matches, which is used to handle responsive behavior in the `RightSection` component.

### Additional Changes:

* [`src/app/components/shared/header/index.tsx`](diffhunk://#diff-339e564354f6b9f679f761207df7f02d8ea55cd11d2a57e1d57ca43b994a3be3L4-R28): Refactored to include the `ReusableBreadcrumb` directly in the header layout, ensuring consistent breadcrumb display across different sections.

These changes collectively enhance the user experience by improving the responsiveness and usability of the header components.